### PR TITLE
the quicksort function supports generics

### DIFF
--- a/scala/src/main/scala/Main.scala
+++ b/scala/src/main/scala/Main.scala
@@ -7,16 +7,17 @@ object Main extends App {
 
     def occurrences: Map[T, Int] =
       t.foldLeft(empty[T, Int]) { (a, v) => a + a.get(v).fold(v -> 1)(x => v -> (x + 1)) }
+
+    def quickSort(implicit f: T => Ordered[T]): List[T] = t match {
+      case Nil => Nil
+      case head :: tail =>
+        val (lower, upper) = tail.partition(_ < head)
+        lower.quickSort ++ List(head) ++ upper.quickSort
+    }
   }
 
-  def quickSort(numbers: List[Int]): List[Int] = numbers match {
-    case Nil => Nil
-    case head :: tail =>
-      val (lower, upper) = tail.partition(_ < head)
-      quickSort(lower) ++ List(head) ++ quickSort(upper)
-  }
-
-  val numbers = fromResource("source").getLines.map(_.toInt).toList
-
-  quickSort(numbers).occurrences.foreach(x => println(s"${x._1}=${x._2}"))
+  fromResource("source").getLines.map(_.toInt).toList
+    .quickSort
+    .occurrences
+    .foreach(x => println(s"${x._1}=${x._2}"))
 }

--- a/scala/src/test/scala/MainTest.scala
+++ b/scala/src/test/scala/MainTest.scala
@@ -1,5 +1,6 @@
 import Main._
 import org.scalatest.{FlatSpec, Matchers}
+
 import scala.util.Random.shuffle
 
 
@@ -7,22 +8,22 @@ class MainTest extends FlatSpec with Matchers {
 
   "Given an empty list" should "return an empty list" in {
 
-    quickSort(List[Int]()) shouldBe empty
+    List[Int]().quickSort shouldBe empty
   }
 
   "Given a list with one element" should "return the same list" in {
 
-    quickSort(List(42)) shouldBe List(42)
+    List(42).quickSort shouldBe List(42)
   }
 
   "Given a list with more than one elements" should "return an ordered list" in {
 
-    quickSort(List(7, 9, 0, 3, 4, 1, 5, 8, 2, 6)) shouldBe sorted
+    List(7, 9, 0, 3, 4, 1, 5, 8, 2, 6).quickSort shouldBe sorted
   }
 
   "Given a list with more than one repeated elements" should "return an ordered list" in {
 
-    quickSort(List(3, 2, 2, 3, 1, 3)) shouldBe sorted
+    List(3, 2, 2, 3, 1, 3).quickSort shouldBe sorted
   }
 
   "Given an ordered list with more than one repeated elements" should "count the occurrences preserving the order" in {
@@ -32,6 +33,6 @@ class MainTest extends FlatSpec with Matchers {
 
   "Given a shuffled list with more than one repeated elements" should "sort it and count the occurrences" in {
 
-    quickSort(shuffle(List(1, 2, 2, 3, 3, 3))).occurrences.toSeq should contain inOrderOnly(1 -> 1, 2 -> 2, 3 -> 3)
+    shuffle(List(1, 2, 2, 3, 3, 3)).quickSort.occurrences.toSeq should contain inOrderOnly(1 -> 1, 2 -> 2, 3 -> 3)
   }
 }


### PR DESCRIPTION
HI again, I've modified the function in order to support a generic list, thanks for your tip. 
I've preferred to avoid using the view bounds due to deprecation ([https://github.com/scala/scala/pull/2909](url)) in favour of an implicit Ordered[T] function.